### PR TITLE
Transfer gateway configurations from application.yml to Annotations in GatewayApplication

### DIFF
--- a/bookstore/pom.xml
+++ b/bookstore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
+        <version>2.1.4.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>me.aboullaite</groupId>
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring-cloud.version>Greenwich.RC2</spring-cloud.version>
+        <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
     </properties>
 
     <dependencies>

--- a/discovery/pom.xml
+++ b/discovery/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
+        <version>2.1.4.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>me.aboullaite</groupId>
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring-cloud.version>Greenwich.RC2</spring-cloud.version>
+        <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
     </properties>
 
     <dependencies>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.1.RELEASE</version>
+        <version>2.1.4.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>me.aboullaite</groupId>
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring-cloud.version>Greenwich.RC2</spring-cloud.version>
+        <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
     </properties>
 
     <dependencies>

--- a/gateway/src/main/java/me/aboullaite/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/me/aboullaite/gateway/GatewayApplication.java
@@ -4,14 +4,19 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
+import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
 import org.springframework.cloud.netflix.hystrix.EnableHystrix;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import reactor.core.publisher.Mono;
 
 @SpringBootApplication
 @EnableEurekaClient
 @EnableHystrix
+@Configuration
 public class GatewayApplication {
 
     public static void main(String[] args) {
@@ -22,6 +27,31 @@ public class GatewayApplication {
     @Bean
     KeyResolver userKeyResolver() {
         return exchange -> Mono.just("fero");
+    }
+
+    @Bean
+    public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
+        return builder.routes()
+                .route("book-store", r -> r.path("/api/books/**")
+                        .filters(f ->
+                                f.rewritePath("/api/(?<books>.*)", "/${books}")
+                                        .hystrix(c -> c.setName("booksFallbackCommand").setFallbackUri("forward:/fallback/books"))
+                                        .requestRateLimiter(c -> c.setRateLimiter(redisRateLimiter()).setKeyResolver(userKeyResolver()))
+                        ).uri("lb://book-store"))
+                .route("movie-store", r -> r.path("/api/movies/**")
+                        .filters(f ->
+                                        f.rewritePath("/api/(?<movies>.*)", "/${movies}")
+                                                .addResponseHeader("X-Some-Header","aboullaite.me")
+                                                .requestRateLimiter(c -> c.setRateLimiter(redisRateLimiter()).setKeyResolver(userKeyResolver()))
+                                //).uri("lb://movie-store"))
+                        ).uri("http://localhost:8890"))
+
+                .build();
+    }
+
+    @Bean
+    RedisRateLimiter redisRateLimiter() {
+        return new RedisRateLimiter(2, 2);
     }
 }
 

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -2,38 +2,38 @@ hystrix.command.fallbackcmd.execution.isolation.thread.timeoutInMilliseconds: 20
 spring:
   application:
     name: api-gateway
-  cloud:
-    gateway:
-      routes:
-      - id: book-store
-        uri: lb://book-store
-        predicates:
-        - Path=/api/books/**
-        filters:
-        - name: RequestRateLimiter
-          args:
-            key-resolver: '#{@userKeyResolver}'
-            redis-rate-limiter.replenishRate: 2
-            redis-rate-limiter.burstCapacity: 2
-        - RewritePath=/api/(?<books>.*), /$\{books}
-        - name: Hystrix
-          args:
-            name: booksFallbackCommand
-            fallbackUri: forward:/fallback/books
-
-
-      - id: movie-store
-        uri: lb://movie-store
-        predicates:
-        - Path=/api/movies/**
-        filters:
-        - name: RequestRateLimiter
-          args:
-            key-resolver: '#{@userKeyResolver}'
-            redis-rate-limiter.replenishRate: 2
-            redis-rate-limiter.burstCapacity: 2
-        - RewritePath=/api/(?<movies>.*), /$\{movies}
-        - AddResponseHeader=X-Some-Header, aboullaite.me
+#  cloud:
+#    gateway:
+#      routes:
+#      - id: book-store
+#        uri: lb://book-store
+#        predicates:
+#        - Path=/api/books/**
+#        filters:
+#        - name: RequestRateLimiter
+#          args:
+#            key-resolver: '#{@userKeyResolver}'
+#            redis-rate-limiter.replenishRate: 2
+#            redis-rate-limiter.burstCapacity: 2
+#        - RewritePath=/api/(?<books>.*), /$\{books}
+#        - name: Hystrix
+#          args:
+#            name: booksFallbackCommand
+#            fallbackUri: forward:/fallback/books
+#
+#
+#      - id: movie-store
+#        uri: lb://movie-store
+#        predicates:
+#        - Path=/api/movies/**
+#        filters:
+#        - name: RequestRateLimiter
+#          args:
+#            key-resolver: '#{@userKeyResolver}'
+#            redis-rate-limiter.replenishRate: 2
+#            redis-rate-limiter.burstCapacity: 2
+#        - RewritePath=/api/(?<movies>.*), /$\{movies}
+#        - AddResponseHeader=X-Some-Header, aboullaite.me
 
 server:
   port: 8887

--- a/hystrix-dashboard/pom.xml
+++ b/hystrix-dashboard/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.2.RELEASE</version>
+		<version>2.1.4.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>me.aboullaite</groupId>
@@ -16,7 +16,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Greenwich.RC2</spring-cloud.version>
+		<spring-cloud.version>Greenwich.SR1</spring-cloud.version>
 	</properties>
 
 	<dependencies>

--- a/moviestore/pom.xml
+++ b/moviestore/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.2.RELEASE</version>
+        <version>2.1.4.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>me.aboullaite</groupId>
@@ -16,7 +16,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <spring-cloud.version>Greenwich.RC2</spring-cloud.version>
+        <spring-cloud.version>Greenwich.SR1</spring-cloud.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Currently, gateway configurations are handled through properties in **application.yml** which is hard to maintain and debug. I've removed them from config file and added the equivalent annotation-based code in **GatewayApplication** class. It is a lot easier to understand, maintain and debug.
In addition, I've upgrade the _Spring Boot_ version from _2.1.1.RELEASE_ to _2.1.4.RELEASE_.